### PR TITLE
Support passing file / folder exclude options

### DIFF
--- a/backend/commands/get_folders.js
+++ b/backend/commands/get_folders.js
@@ -8,10 +8,13 @@ module.exports = (data, callback) => {
     }
     const result = [];
     const promises = folders
-        .filter(d => fs.existsSync(d))
-        .map(d => esmExports(d, { type: 'directory' }).then(items => {
-            result.push(...items);
-        }));
+        .map(d => {
+            if (fs.existsSync(d)) {
+                return esmExports(d, { type: 'directory', ignorePatterns: (data.ignore || {})[d] })
+                    .then(items => result.push(...items));
+            }
+        });
+
     return Promise.all(promises)
         .then(() => {
             callback(null, result);

--- a/backend/test.js
+++ b/backend/test.js
@@ -106,6 +106,46 @@ it('get_folders command', (done) => {
     });
 });
 
+it('get_folders command with ignore patterns', (done) => {
+    const folder1 = Path.join(rootPath, 'test_playground/app/t1');
+    const folder2 = Path.join(rootPath, 'test_playground/app/t2');
+    const ignore = {
+        [folder1]: ['**/volumes'],
+        [folder2]: ['dummy.component.ts'],
+    };
+
+    getFoldersCmd({
+        folders: [folder1, folder2],
+        ignore,
+    }, (err, result) => {
+        if (err) return done(err);
+
+        let hasTest = false;
+        let numX2 = 0;
+        let hasVolume = false;
+        let hasDummy = false;
+        result.forEach(({ filepath, name }) => {
+            if (name === 'test') {
+                hasTest = true;
+            }
+            if (name === 'x2') {
+                numX2++;
+            }
+            if (name === 'VOLUME' || filepath.indexOf('/volumes/') !== -1) {
+                hasVolume = true;
+            }
+            if (name === 'DummyComponent' || /dummy\.component\.ts$/.test(filepath)) {
+                hasDummy = true;
+            }
+        });
+        assert(hasTest === true);
+        assert(numX2 > 1);
+        assert(hasVolume === false);
+        assert(hasDummy === false);
+        done();
+    });
+});
+
 it('get_modules command', (done) => {
     getModulesCmd({
 

--- a/import_helper.py
+++ b/import_helper.py
@@ -37,18 +37,17 @@ def update_source_modules():
             sublime.error_message(PROJECT_NAME + '\n' + str(err))
             return
         source_modules.clear();
-        exclude_patterns = get_exclude_patterns()
         if type(result) is not list:
             sublime.error_message(PROJECT_NAME + '\n' + 'Unexpected type of result: ' + type(result))
             return
         for item in result:
             filepath = item.get('filepath')
             if filepath is None: continue
-            if is_excluded_file(filepath, exclude_patterns): continue
             source_modules.append(item)
         sublime.status_message('{0}: {1} source modules found'.format(PROJECT_NAME, len(source_modules)))
         debug('Update source modules', len(source_modules))
-    run_command_async('get_folders', {'folders': source_folders}, get_source_modules_callback)
+    exclude_patterns = get_exclude_patterns()
+    run_command_async('get_folders', { 'folders': source_folders, 'ignore': exclude_patterns }, get_source_modules_callback)
 
 def update_node_modules():
     node_modules.clear()
@@ -116,7 +115,7 @@ class InitializeSetupCommand(sublime_plugin.WindowCommand):
 
 # window.run_command('update_source_modules')
 class UpdateSourceModulesCommand(sublime_plugin.WindowCommand):
-    
+
     def run(self):
         update_source_modules()
 

--- a/test_playground/app/t1/src/component/index.ts
+++ b/test_playground/app/t1/src/component/index.ts
@@ -1,0 +1,1 @@
+export const test = 5;

--- a/test_playground/app/t1/volumes/x/test.ts
+++ b/test_playground/app/t1/volumes/x/test.ts
@@ -1,0 +1,1 @@
+export const VOLUME = 11;

--- a/test_playground/app/t2/src/component/abc.component.ts
+++ b/test_playground/app/t2/src/component/abc.component.ts
@@ -1,0 +1,3 @@
+export class AbcComponent { }
+
+export const AbcConfig = 1;

--- a/test_playground/app/t2/src/component/about.component.ts
+++ b/test_playground/app/t2/src/component/about.component.ts
@@ -1,0 +1,1 @@
+export class AboutComponent { }

--- a/test_playground/app/t2/src/component/dummy.component.ts
+++ b/test_playground/app/t2/src/component/dummy.component.ts
@@ -1,0 +1,1 @@
+export class DummyComponent { }

--- a/test_playground/app/t2/src/component/index.ts
+++ b/test_playground/app/t2/src/component/index.ts
@@ -1,0 +1,2 @@
+export * from './abc.component';
+export * from './x.component';

--- a/test_playground/app/t2/src/component/x.component.ts
+++ b/test_playground/app/t2/src/component/x.component.ts
@@ -1,0 +1,2 @@
+export const x1 = 1;
+export * from './x';

--- a/test_playground/app/t2/src/component/x/index.ts
+++ b/test_playground/app/t2/src/component/x/index.ts
@@ -1,0 +1,3 @@
+export * from './x2.component';
+export const index1 = 1;
+export const index2 = 2;

--- a/test_playground/app/t2/src/component/x/x2.component.ts
+++ b/test_playground/app/t2/src/component/x/x2.component.ts
@@ -1,0 +1,1 @@
+export function x2() { }

--- a/utils.py
+++ b/utils.py
@@ -189,8 +189,9 @@ def find_executable(executable, path = None):
 
 def get_exclude_patterns(project_data = None):
     if project_data is None: project_data = sublime.active_window().project_data()
-    result = []
+    data = {}
     for folder in ((project_data or {}).get('folders') or []):
+        result = []
         folder_exclude_patterns = folder.get('folder_exclude_patterns')
         if folder_exclude_patterns is None: folder_exclude_patterns = []
         for pattern in folder_exclude_patterns:
@@ -199,7 +200,12 @@ def get_exclude_patterns(project_data = None):
         if file_exclude_patterns is None: file_exclude_patterns = []
         for pattern in file_exclude_patterns:
             result.append(pattern)
-    return result
+        binary_file_patterns = folder.get('binary_file_patterns')
+        if binary_file_patterns is None: binary_file_patterns = []
+        for pattern in binary_file_patterns:
+            result.append(pattern)
+        data[folder] = result
+    return data
 
 def read_json(file):
     if not os.path.isfile(file):


### PR DESCRIPTION
RE: https://github.com/unlight/esm-exports/pull/14

This would prevent the plugin from crashing when a large project-ignored folder is processed. Currently, I have manually edited the packages in my sublime config in order to retain imports in that project file, but naturally that means any updates would likely break it.

Assuming the other PR is merged in and the package published, `package.json` would need a version bump (3.0.4+ possibly).

Realistically this could be merged in without the other PR, but that doesn't make any sense and it causes the tests to fail.
I was able to run the tests by importing locally, just to make sure:
```
// get_folders.js
const { esmExports } = require('../../esm-exports/dist');
```