### PR TITLE
Strip extension setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ Remove index suffix ending in file path
 -   Type: `boolean`
 -   Default: `true`
 
+#### import_strip_extension
+
+Strip file extension in import statement.
+
+-   Type: `boolean`
+-   Default: `true`
+
 #### `import_root` (project file only)
 
 Path to your project root folder (not source folder). If not set,

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Remove index suffix ending in file path
 -   Type: `boolean`
 -   Default: `true`
 
-#### import_strip_extension
+#### `import_strip_extension`
 
 Strip file extension in import statement.
 

--- a/import_helper.sublime-settings
+++ b/import_helper.sublime-settings
@@ -42,5 +42,10 @@
     // - Type: `boolean`  
     // - Default: `false`
     "remove_trailing_index": true,
+
+    // Strip file extension in import statement.
+    // - Type: `boolean`
+    // - Default: true
+    "import_strip_extension": true,
 }
 

--- a/library/get_from_paths.py
+++ b/library/get_from_paths.py
@@ -12,7 +12,7 @@ def get_from_paths(item, file_name=None, typescript_paths=[]):
     if not file_name:
         file_name = "."
     from_path = os.path.relpath(item["filepath"], os.path.dirname(file_name))
-    from_path = unixify(from_path)
+    from_path = unixify(from_path, get_setting("import_strip_extension", True))
     if from_path[0] != ".":
         from_path = "./" + from_path
     result = [from_path]

--- a/library/unixify.py
+++ b/library/unixify.py
@@ -1,9 +1,10 @@
-def unixify(path):
+def unixify(path, stripext=True):
     path = path.replace("\\", "/")
-    ext3 = path[-3:]
-    if ext3 == ".ts" or ext3 == ".js":
-        return path[0:-3]
-    ext4 = path[-4:]
-    if ext4 == ".tsx" or ext4 == ".jsx":
-        return path[0:-4]
+    if stripext:
+        ext3 = path[-3:]
+        if ext3 == ".ts" or ext3 == ".js":
+            return path[0:-3]
+        ext4 = path[-4:]
+        if ext4 == ".tsx" or ext4 == ".jsx":
+            return path[0:-4]
     return path


### PR DESCRIPTION
I've been using this for a while for the case of using ES6 modules natively in the browser, without a bundler. As far as I have tested the file extension is required in the import statements so useful to have an option to preserve it.